### PR TITLE
Reps to beat

### DIFF
--- a/wendler/src/main/java/se/johan/wendler/fragment/WorkoutMainFragment.java
+++ b/wendler/src/main/java/se/johan/wendler/fragment/WorkoutMainFragment.java
@@ -122,6 +122,7 @@ public class WorkoutMainFragment extends WorkoutFragment implements
      */
     public void updateProgress(int number) {
         mMainExercise.setLastSetProgress(number);
+        mMainExercise.recalculateEstOneRm();
         updateFooter();
         getActivity().invalidateOptionsMenu();
         mAdapter.notifyDataSetChanged();

--- a/wendler/src/main/java/se/johan/wendler/model/MainExercise.java
+++ b/wendler/src/main/java/se/johan/wendler/model/MainExercise.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import se.johan.wendler.model.base.Exercise;
+import se.johan.wendler.util.WendlerMath;
 
 /**
  * Object representing a main exercise.
@@ -29,7 +30,7 @@ public class MainExercise extends Exercise implements Parcelable {
                         ArrayList<ExerciseSet> exerciseSets,
                         List<SetGroup> setGroups,
                         int workoutPercentage,
-                        //int estOneRm,
+                        int estOneRm,
                         int repsToBeat) {
         mName = name;
         mWeight = weight;
@@ -37,7 +38,7 @@ public class MainExercise extends Exercise implements Parcelable {
         mExerciseSets = exerciseSets;
         mWorkoutPercentage = workoutPercentage;
         mSetGroups = setGroups;
-        //mEstOneRm = estOneRm;
+        mEstOneRm = estOneRm;
 
         mRepsToBeat = repsToBeat;
 
@@ -114,6 +115,13 @@ public class MainExercise extends Exercise implements Parcelable {
     }
 
     /**
+     * Recalculates the estimated One RM based on last set weight and reps
+     */
+    public void recalculateEstOneRm(){
+        mEstOneRm = WendlerMath.calculateOneRm(getLastSetWeight(), getLastSetProgress());
+    }
+
+    /**
      * Returns the set groups.
      */
     public List<SetGroup> getSetGroups() {
@@ -156,6 +164,8 @@ public class MainExercise extends Exercise implements Parcelable {
             dest.writeByte((byte) (0x01));
             dest.writeList(mSetGroups);
         }
+        dest.writeInt(mRepsToBeat);
+        dest.writeInt(mEstOneRm);
     }
 
     /**
@@ -178,6 +188,8 @@ public class MainExercise extends Exercise implements Parcelable {
         } else {
             mSetGroups = null;
         }
+        mRepsToBeat = in.readInt();
+        mEstOneRm = in.readInt();
     }
 
     /**

--- a/wendler/src/main/java/se/johan/wendler/model/MainExercise.java
+++ b/wendler/src/main/java/se/johan/wendler/model/MainExercise.java
@@ -19,6 +19,7 @@ public class MainExercise extends Exercise implements Parcelable {
     private int mWorkoutPercentage;
     private LinkedHashMap<SetType, List<ExerciseSet>> mSetGroups;
     private int mRepsToBeat;
+    private int mEstOneRm;
 
     /**
      * Constructor.
@@ -29,6 +30,7 @@ public class MainExercise extends Exercise implements Parcelable {
                         ArrayList<ExerciseSet> exerciseSets,
                         LinkedHashMap<SetType, List<ExerciseSet>> setGroups,
                         int workoutPercentage,
+                        //int estOneRm,
                         int repsToBeat) {
         mName = name;
         mWeight = weight;
@@ -36,7 +38,10 @@ public class MainExercise extends Exercise implements Parcelable {
         mExerciseSets = exerciseSets;
         mWorkoutPercentage = workoutPercentage;
         mSetGroups = setGroups;
+        //mEstOneRm = estOneRm;
+
         mRepsToBeat = repsToBeat;
+
     }
 
     /**
@@ -99,6 +104,14 @@ public class MainExercise extends Exercise implements Parcelable {
      */
     public int getRepsToBeat() {
         return mRepsToBeat;
+    }
+
+    /**
+     * Return the estimated One RM based on the last set
+     * @return
+     */
+    public int getEstOneRm() {
+        return mEstOneRm;
     }
 
     /**
@@ -169,4 +182,5 @@ public class MainExercise extends Exercise implements Parcelable {
             return new MainExercise[size];
         }
     };
+
 }

--- a/wendler/src/main/java/se/johan/wendler/model/MainExercise.java
+++ b/wendler/src/main/java/se/johan/wendler/model/MainExercise.java
@@ -17,6 +17,7 @@ public class MainExercise extends Exercise implements Parcelable {
     private double mWeight;
     private int mWorkoutPercentage;
     private List<SetGroup> mSetGroups = new ArrayList<>();
+	private int mRepsToBeat;
 
     /**
      * Constructor.
@@ -26,13 +27,15 @@ public class MainExercise extends Exercise implements Parcelable {
                         double increment,
                         ArrayList<ExerciseSet> exerciseSets,
                         List<SetGroup> setGroups,
-                        int workoutPercentage) {
+                        int workoutPercentage,
+                        int repsToBeat) {
         mName = name;
         mWeight = weight;
         mIncrement = increment;
         mExerciseSets = exerciseSets;
         mWorkoutPercentage = workoutPercentage;
         mSetGroups = setGroups;
+        mRepsToBeat = repsToBeat;
     }
 
     /**
@@ -87,6 +90,14 @@ public class MainExercise extends Exercise implements Parcelable {
     public double getLastSetWeight() {
         int size = mExerciseSets.size();
         return mExerciseSets.get(size - 1).getWeight();
+    }
+
+    /**
+     * Return the reps to beat for a new PR
+     * @return
+     */
+    public int getRepsToBeat() {
+        return mRepsToBeat;
     }
 
     /**

--- a/wendler/src/main/java/se/johan/wendler/model/MainExercise.java
+++ b/wendler/src/main/java/se/johan/wendler/model/MainExercise.java
@@ -18,6 +18,7 @@ public class MainExercise extends Exercise implements Parcelable {
     private double mWeight;
     private int mWorkoutPercentage;
     private LinkedHashMap<SetType, List<ExerciseSet>> mSetGroups;
+    private int mRepsToBeat;
 
     /**
      * Constructor.
@@ -27,13 +28,15 @@ public class MainExercise extends Exercise implements Parcelable {
                         double increment,
                         ArrayList<ExerciseSet> exerciseSets,
                         LinkedHashMap<SetType, List<ExerciseSet>> setGroups,
-                        int workoutPercentage) {
+                        int workoutPercentage,
+                        int repsToBeat) {
         mName = name;
         mWeight = weight;
         mIncrement = increment;
         mExerciseSets = exerciseSets;
         mWorkoutPercentage = workoutPercentage;
         mSetGroups = setGroups;
+        mRepsToBeat = repsToBeat;
     }
 
     /**
@@ -88,6 +91,14 @@ public class MainExercise extends Exercise implements Parcelable {
     public double getLastSetWeight() {
         int size = mExerciseSets.size();
         return mExerciseSets.get(size - 1).getWeight();
+    }
+
+    /**
+     * Return the reps to beat for a new PR
+     * @return
+     */
+    public int getRepsToBeat() {
+        return mRepsToBeat;
     }
 
     /**

--- a/wendler/src/main/java/se/johan/wendler/model/MainExercise.java
+++ b/wendler/src/main/java/se/johan/wendler/model/MainExercise.java
@@ -17,7 +17,8 @@ public class MainExercise extends Exercise implements Parcelable {
     private double mWeight;
     private int mWorkoutPercentage;
     private List<SetGroup> mSetGroups = new ArrayList<>();
-	private int mRepsToBeat;
+    private int mRepsToBeat;
+    private int mEstOneRm;
 
     /**
      * Constructor.
@@ -28,6 +29,7 @@ public class MainExercise extends Exercise implements Parcelable {
                         ArrayList<ExerciseSet> exerciseSets,
                         List<SetGroup> setGroups,
                         int workoutPercentage,
+                        //int estOneRm,
                         int repsToBeat) {
         mName = name;
         mWeight = weight;
@@ -35,7 +37,10 @@ public class MainExercise extends Exercise implements Parcelable {
         mExerciseSets = exerciseSets;
         mWorkoutPercentage = workoutPercentage;
         mSetGroups = setGroups;
+        //mEstOneRm = estOneRm;
+
         mRepsToBeat = repsToBeat;
+
     }
 
     /**
@@ -98,6 +103,14 @@ public class MainExercise extends Exercise implements Parcelable {
      */
     public int getRepsToBeat() {
         return mRepsToBeat;
+    }
+
+    /**
+     * Return the estimated One RM based on the last set
+     * @return
+     */
+    public int getEstOneRm() {
+        return mEstOneRm;
     }
 
     /**
@@ -180,4 +193,5 @@ public class MainExercise extends Exercise implements Parcelable {
             return new MainExercise[size];
         }
     };
+
 }

--- a/wendler/src/main/java/se/johan/wendler/sql/SqlHandler.java
+++ b/wendler/src/main/java/se/johan/wendler/sql/SqlHandler.java
@@ -427,7 +427,12 @@ public class SqlHandler {
                 sets.addAll(set);
                 setGroups.add(new SetGroup(SetType.REGULAR, set));
 
-                return new MainExercise(name, oneRm, increment, sets, setGroups, workoutPercentage);
+                int highestEstimated1RM = getHighestEstimated1RM(name);
+
+                int repsToBeat = WendlerMath.getRepsToBeat(mContext, set, highestEstimated1RM);
+
+
+                return new MainExercise(name, oneRm, increment, sets, setGroups, workoutPercentage, repsToBeat);
             }
             return null;
         } finally {
@@ -541,6 +546,13 @@ public class SqlHandler {
         }
     }
 
+
+    public int getHighestEstimated1RM(String name){
+        // TODO
+
+        return -1;
+    }
+
     /**
      * Return additional exercise names stored as permanent exercises.
      */
@@ -585,6 +597,7 @@ public class SqlHandler {
         }
 
     }
+
 
     /**
      * Store the main exercise and return if it was successful.
@@ -1305,8 +1318,11 @@ public class SqlHandler {
                 sets.addAll(set);
                 setGroups.add(new SetGroup(SetType.REGULAR, sets));
 
-                mainExercise = new MainExercise(
-                        name, oneRm, increment, sets, setGroups, workoutPercentage);
+                int highestEstimated1RM = getHighestEstimated1RM(name);
+
+                int repsToBeat = WendlerMath.getRepsToBeat(mContext, set, highestEstimated1RM);
+
+                mainExercise = new MainExercise(name, oneRm, increment, sets, setGroups, workoutPercentage, repsToBeat);
             }
 
             if (!isComplete && mainExercise != null && mainExercise.getLastSetProgress() < 0) {

--- a/wendler/src/main/java/se/johan/wendler/sql/SqlHandler.java
+++ b/wendler/src/main/java/se/johan/wendler/sql/SqlHandler.java
@@ -427,7 +427,12 @@ public class SqlHandler {
                 sets.addAll(set);
                 setGroups.put(SetType.REGULAR, set);
 
-                return new MainExercise(name, oneRm, increment, sets, setGroups, workoutPercentage);
+                int highestEstimated1RM = getHighestEstimated1RM(name);
+
+                int repsToBeat = WendlerMath.getRepsToBeat(mContext, set, highestEstimated1RM);
+
+
+                return new MainExercise(name, oneRm, increment, sets, setGroups, workoutPercentage, repsToBeat);
             }
             return null;
         } finally {
@@ -541,6 +546,13 @@ public class SqlHandler {
         }
     }
 
+
+    public int getHighestEstimated1RM(String name){
+        // TODO
+
+        return -1;
+    }
+
     /**
      * Return additional exercise names stored as permanent exercises.
      */
@@ -585,6 +597,7 @@ public class SqlHandler {
         }
 
     }
+
 
     /**
      * Store the main exercise and return if it was successful.
@@ -1304,8 +1317,11 @@ public class SqlHandler {
                 sets.addAll(set);
                 setGroups.put(SetType.REGULAR, set);
 
-                mainExercise = new MainExercise(
-                        name, oneRm, increment, sets, setGroups, workoutPercentage);
+                int highestEstimated1RM = getHighestEstimated1RM(name);
+
+                int repsToBeat = WendlerMath.getRepsToBeat(mContext, set, highestEstimated1RM);
+
+                mainExercise = new MainExercise(name, oneRm, increment, sets, setGroups, workoutPercentage, repsToBeat);
             }
 
             if (!isComplete && mainExercise != null && mainExercise.getLastSetProgress() < 0) {

--- a/wendler/src/main/java/se/johan/wendler/sql/SqlHandler.java
+++ b/wendler/src/main/java/se/johan/wendler/sql/SqlHandler.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import se.johan.wendler.model.AdditionalExercise;
@@ -82,6 +83,7 @@ public class SqlHandler {
     private static final String KEY_WORKOUT_NOTES = "notes";
     private static final String KEY_WORKOUT_WON = "workout_won";
     private static final String KEY_WORKOUT_COMPLETED = "workout_completed";
+    private static final String KEY_WORKOUT_EST_ONE_RM = "est_one_rm";
 
     /**
      * Extra workout table *
@@ -427,10 +429,13 @@ public class SqlHandler {
                 sets.addAll(set);
                 setGroups.add(new SetGroup(SetType.REGULAR, set));
 
+                //ExerciseSet lastSet = sets.get(sets.size()-1);
+
+                //int estOneRm = WendlerMath.calculateOneRm(lastSet.getWeight(), lastSet.)
+
                 int highestEstimated1RM = getHighestEstimated1RM(name);
 
                 int repsToBeat = WendlerMath.getRepsToBeat(mContext, set, highestEstimated1RM);
-
 
                 return new MainExercise(name, oneRm, increment, sets, setGroups, workoutPercentage, repsToBeat);
             }
@@ -547,10 +552,30 @@ public class SqlHandler {
     }
 
 
-    public int getHighestEstimated1RM(String name){
-        // TODO
+    public int getHighestEstimated1RM(String name){ // TODO test performance
+        String[] columns = new String[]{KEY_WORKOUT_LAST_SET, KEY_WORKOUT_REPS};
+        ArrayList<Integer> estOneRms = new ArrayList<>();
+        estOneRms.add(-1); // ensure that Collections.max will always return something
 
-        return -1;
+        Cursor cursor = null;
+        try{
+            cursor = mDatabase.query(DATABASE_TABLE_WENDLER_WORKOUT, columns, KEY_WORKOUT_EXERCISE + "=?", new String[]{name},null, null, null);
+            if(cursor != null && cursor.moveToFirst()){
+                do{
+                    int weight = cursor.getInt(cursor.getColumnIndex(KEY_WORKOUT_LAST_SET));
+                    int reps = cursor.getInt(cursor.getColumnIndex(KEY_WORKOUT_REPS));
+                    int estOneRm = WendlerMath.calculateOneRm(weight, reps);
+                    estOneRms.add(estOneRm);
+                }while(cursor.moveToNext());
+            }
+
+            int highestEstimatedOneRm = Collections.max(estOneRms);
+            return highestEstimatedOneRm;
+        }finally{
+            if(cursor != null){
+                cursor.close();
+            }
+        }
     }
 
     /**
@@ -608,6 +633,7 @@ public class SqlHandler {
         double oneRm = workout.getMainExercise().getWeight();
         int size = workout.getMainExercise().getExerciseSets().size();
         double lastSet = workout.getMainExercise().getExerciseSet(size - 1).getWeight();
+        int estOneRm = workout.getMainExercise().getEstOneRm();
 
         cv.put(KEY_WORKOUT_ID, workout.getWorkoutId());
         cv.put(KEY_WORKOUT_EXERCISE, workout.getName());
@@ -1554,6 +1580,7 @@ public class SqlHandler {
      */
     private static class DbHelper extends SQLiteOpenHelper {
 
+
         private final Context mContext;
 
         /**
@@ -1615,7 +1642,9 @@ public class SqlHandler {
                     KEY_WORKOUT_NOTES + " TEXT NOT NULL, " +
                     KEY_WORKOUT_COMPLETED + " INTEGER NOT NULL, " +
                     KEY_TRAINING_PERCENTAGE + " INTEGER NOT NULL, " +
-                    KEY_WORKOUT_WON + " INTEGER);");
+                    KEY_WORKOUT_WON + " INTEGER);"
+                    //+ KEY_WORKOUT_EST_ONE_RM + "INTEGER"
+            );
 
             /**
              * Table for managing extra exercises for a specific workout.

--- a/wendler/src/main/java/se/johan/wendler/ui/adapter/MainExerciseAdapter.java
+++ b/wendler/src/main/java/se/johan/wendler/ui/adapter/MainExerciseAdapter.java
@@ -79,6 +79,7 @@ public class MainExerciseAdapter extends BaseAdapter {
 
         List<ExerciseSet> sets = getSetsByIndex(position);
         SetType setType = getTypeByIndex(position);
+        boolean shouldShowRepsToBeat = shouldShowRepsToBeat(setType, mMainExercise);
 
         final ViewHolder holder;
         if (convertView == null) {
@@ -88,6 +89,7 @@ public class MainExerciseAdapter extends BaseAdapter {
             holder.setOne = (TextView) convertView.findViewById(R.id.set_one);
             holder.setTwo = (TextView) convertView.findViewById(R.id.set_two);
             holder.setThree = (TextView) convertView.findViewById(R.id.set_three);
+            holder.repsToBeat = (TextView) convertView.findViewById(R.id.reps_to_beat);
             holder.imageView = (ImageView) convertView.findViewById(R.id.image_view);
             String text = getSetTypeString(setType, true);
             int color = ColorGenerator.DEFAULT.getColor(text);
@@ -103,6 +105,7 @@ public class MainExerciseAdapter extends BaseAdapter {
         final ExerciseSet setOne = sets.get(0);
         final ExerciseSet setTwo = sets.get(1);
         final ExerciseSet setThree = sets.get(2);
+        final int repsToBeat = getRepsToBeat();
 
         String plusSet = setThree.getType().equals(SetType.PLUS_SET) ? "+" : "";
 
@@ -120,6 +123,14 @@ public class MainExerciseAdapter extends BaseAdapter {
                 String.format(mContext.getString(R.string.exercise_set_three),
                         String.valueOf(setThree.getWeight()),
                         String.valueOf(setThree.getGoal())) + plusSet);
+
+        if (shouldShowRepsToBeat) {
+            holder.repsToBeat.setText(
+                    String.format(mContext.getString(R.string.reps_to_beat),
+                            String.valueOf(repsToBeat)));
+        } else {
+            holder.repsToBeat.setVisibility(View.GONE);
+        }
 
         setOnClick(holder.setOne, setOne);
         setOnClick(holder.setTwo, setTwo);
@@ -142,6 +153,10 @@ public class MainExerciseAdapter extends BaseAdapter {
         setPaint(holder.setThree, setThree);
 
         return convertView;
+    }
+
+    private boolean shouldShowRepsToBeat(SetType setType, MainExercise mainExercise) {
+        return setType == SetType.REGULAR && mainExercise.getRepsToBeat() != -1;
     }
 
     /**
@@ -209,6 +224,13 @@ public class MainExerciseAdapter extends BaseAdapter {
     }
 
     /**
+     * Returns the reps to beat for a new PR
+     */
+    private int getRepsToBeat() {
+        return mMainExercise.getRepsToBeat();
+    }
+
+    /**
      * Returns the set type string based on set type and if it's displayed as a short.
      */
     private String getSetTypeString(SetType type, boolean shortType) {
@@ -236,5 +258,6 @@ public class MainExerciseAdapter extends BaseAdapter {
         public TextView setThree;
         public ImageView imageView;
         public TextDrawable textDrawable;
+        public TextView repsToBeat;
     }
 }

--- a/wendler/src/main/java/se/johan/wendler/ui/adapter/MainExerciseAdapter.java
+++ b/wendler/src/main/java/se/johan/wendler/ui/adapter/MainExerciseAdapter.java
@@ -79,6 +79,7 @@ public class MainExerciseAdapter extends BaseAdapter {
 
         List<ExerciseSet> sets = getSetsByIndex(position);
         SetType setType = getTypeByIndex(position);
+        boolean shouldShowRepsToBeat = shouldShowRepsToBeat(setType, mMainExercise);
 
         final ViewHolder holder;
         if (convertView == null) {
@@ -88,6 +89,7 @@ public class MainExerciseAdapter extends BaseAdapter {
             holder.setOne = (TextView) convertView.findViewById(R.id.set_one);
             holder.setTwo = (TextView) convertView.findViewById(R.id.set_two);
             holder.setThree = (TextView) convertView.findViewById(R.id.set_three);
+            holder.repsToBeat = (TextView) convertView.findViewById(R.id.reps_to_beat);
             holder.imageView = (ImageView) convertView.findViewById(R.id.image_view);
             String text = getSetTypeString(setType, true);
             int color = ColorGenerator.DEFAULT.getColor(text);
@@ -103,6 +105,7 @@ public class MainExerciseAdapter extends BaseAdapter {
         final ExerciseSet setOne = sets.get(0);
         final ExerciseSet setTwo = sets.get(1);
         final ExerciseSet setThree = sets.get(2);
+        final int repsToBeat = getRepsToBeat();
 
         String plusSet = setThree.getType().equals(SetType.PLUS_SET) ? "+" : "";
 
@@ -120,6 +123,14 @@ public class MainExerciseAdapter extends BaseAdapter {
                 String.format(mContext.getString(R.string.exercise_set_three),
                         String.valueOf(setThree.getWeight()),
                         String.valueOf(setThree.getGoal())) + plusSet);
+
+        if (shouldShowRepsToBeat) {
+            holder.repsToBeat.setText(
+                    String.format(mContext.getString(R.string.reps_to_beat),
+                            String.valueOf(repsToBeat)));
+        } else {
+            holder.repsToBeat.setVisibility(View.GONE);
+        }
 
         setOnClick(holder.setOne, setOne);
         setOnClick(holder.setTwo, setTwo);
@@ -142,6 +153,10 @@ public class MainExerciseAdapter extends BaseAdapter {
         setPaint(holder.setThree, setThree);
 
         return convertView;
+    }
+
+    private boolean shouldShowRepsToBeat(SetType setType, MainExercise mainExercise) {
+        return setType == SetType.REGULAR && mainExercise.getRepsToBeat() != -1;
     }
 
     /**
@@ -210,6 +225,13 @@ public class MainExerciseAdapter extends BaseAdapter {
     }
 
     /**
+     * Returns the reps to beat for a new PR
+     */
+    private int getRepsToBeat() {
+        return mMainExercise.getRepsToBeat();
+    }
+
+    /**
      * Returns the set type string based on set type and if it's displayed as a short.
      */
     private String getSetTypeString(SetType type, boolean shortType) {
@@ -237,5 +259,6 @@ public class MainExerciseAdapter extends BaseAdapter {
         public TextView setThree;
         public ImageView imageView;
         public TextDrawable textDrawable;
+        public TextView repsToBeat;
     }
 }

--- a/wendler/src/main/java/se/johan/wendler/util/WendlerMath.java
+++ b/wendler/src/main/java/se/johan/wendler/util/WendlerMath.java
@@ -22,7 +22,7 @@ public class WendlerMath {
      */
     public static int calculateOneRm(double weight, int reps) {
         if(reps <= 0){
-            return 0;
+            return -1;
         }
         double mOneRm = weight * reps * 0.0333 + weight;
         return (int) Math.round(mOneRm);

--- a/wendler/src/main/java/se/johan/wendler/util/WendlerMath.java
+++ b/wendler/src/main/java/se/johan/wendler/util/WendlerMath.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import se.johan.wendler.R;
 import se.johan.wendler.model.DeloadItem;
@@ -280,5 +281,10 @@ public class WendlerMath {
             intArray[i] = Integer.parseInt(stringArray[i]);
         }
         return intArray;
+    }
+
+    public static int getRepsToBeat(Context context, List<ExerciseSet> sets, int highestEstimated1RM) {
+        // TODO
+        return 99;
     }
 }

--- a/wendler/src/main/java/se/johan/wendler/util/WendlerMath.java
+++ b/wendler/src/main/java/se/johan/wendler/util/WendlerMath.java
@@ -284,7 +284,32 @@ public class WendlerMath {
     }
 
     public static int getRepsToBeat(Context context, List<ExerciseSet> sets, int highestEstimated1RM) {
-        // TODO
-        return 99;
+        ExerciseSet lastSet = sets.get(sets.size()-1);
+
+        double oneRmReps = calculateOneRmReps(lastSet.getWeight(), highestEstimated1RM);
+        int ceilOneRmReps = (int) Math.ceil(oneRmReps);
+
+        if(calculateOneRm(lastSet.getWeight(), ceilOneRmReps) <= highestEstimated1RM){
+            return ceilOneRmReps + 1;
+        }else{
+            return ceilOneRmReps;
+        }
+    }
+
+    public static double calculateOneRmReps(double weight, double oneRm){
+        double constant = 0.0333;
+        double mReps = 1 / ((weight * constant)/(oneRm-weight));
+        return mReps;
+
+        /**
+         * Proof (probably horrible math):
+         * O = (w*r*c) + w
+         * O–w = w*r*c
+         * (o-w)/r = w*c
+         * (o-w)*(1/r) = w*c
+         * 1/r = (w*c)/(o-w)
+         * R = 1/((w*c)/(o-w))
+         * QED
+         */
     }
 }

--- a/wendler/src/main/java/se/johan/wendler/util/WendlerMath.java
+++ b/wendler/src/main/java/se/johan/wendler/util/WendlerMath.java
@@ -21,6 +21,9 @@ public class WendlerMath {
      * Calculate one rm for a given weight and repetitions.
      */
     public static int calculateOneRm(double weight, int reps) {
+        if(reps <= 0){
+            return 0;
+        }
         double mOneRm = weight * reps * 0.0333 + weight;
         return (int) Math.round(mOneRm);
     }
@@ -284,6 +287,10 @@ public class WendlerMath {
     }
 
     public static int getRepsToBeat(Context context, List<ExerciseSet> sets, int highestEstimated1RM) {
+        if(highestEstimated1RM == -1){
+            return -1;
+        }
+
         ExerciseSet lastSet = sets.get(sets.size()-1);
 
         double oneRmReps = calculateOneRmReps(lastSet.getWeight(), highestEstimated1RM);

--- a/wendler/src/main/res/layout/card_main_exercise.xml
+++ b/wendler/src/main/res/layout/card_main_exercise.xml
@@ -66,6 +66,15 @@
                 android:paddingBottom="@dimen/spacing_small"
                 tools:text="22.5 x 5"
                 android:background="?attr/selectableItemBackground"/>
+
+            <TextView
+                android:id="@+id/reps_to_beat"
+                style="@style/CardView.Subtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="@dimen/spacing_small"
+                android:paddingBottom="@dimen/spacing_small"
+                tools:text="Reps for PR: 10"/>
         </LinearLayout>
     </LinearLayout>
 </android.support.v7.widget.CardView>

--- a/wendler/src/main/res/values/strings.xml
+++ b/wendler/src/main/res/values/strings.xml
@@ -93,6 +93,7 @@
     <string name="exercise_set_one">Set 1: %1$s &#x00d7; %2$s</string>
     <string name="exercise_set_two">Set 2: %1$s &#x00d7; %2$s</string>
     <string name="exercise_set_three">Set 3: %1$s &#x00d7; %2$s</string>
+    <string name="reps_to_beat">Reps to beat PR: %1$s</string>
     <string name="one_rm_with_number">Estimated 1RM: %1$s</string>
     <string name="performed_reps_with_number">Reps: %1$s</string>
     <string name="extra_exercise_weight">Weight: %1$s</string>


### PR DESCRIPTION
I added a feature that allows users to quickly see how many reps they need to get on the last set of a workout, to set a new PR. I added a column to the workout table, where the estimated 1RM based on the last set is saved for each workout. This is then used when getting the new workout to calculate the required number of reps, which is displayed in the workout screen.

Please review, and don't hesitate to criticise. Let me know if any changes need to be made before this can be pulled. Thanks!
