### PR TITLE
Added 'reps-to-beat' feature

### DIFF
--- a/wendler/src/main/java/se/johan/wendler/fragment/WorkoutMainFragment.java
+++ b/wendler/src/main/java/se/johan/wendler/fragment/WorkoutMainFragment.java
@@ -122,6 +122,7 @@ public class WorkoutMainFragment extends WorkoutFragment implements
      */
     public void updateProgress(int number) {
         mMainExercise.setLastSetProgress(number);
+        mMainExercise.recalculateEstOneRm();
         updateFooter();
         getActivity().invalidateOptionsMenu();
         mAdapter.notifyDataSetChanged();

--- a/wendler/src/main/java/se/johan/wendler/model/MainExercise.java
+++ b/wendler/src/main/java/se/johan/wendler/model/MainExercise.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import se.johan.wendler.model.base.Exercise;
+import se.johan.wendler.util.WendlerMath;
 
 /**
  * Object representing a main exercise.
@@ -17,6 +18,8 @@ public class MainExercise extends Exercise implements Parcelable {
     private double mWeight;
     private int mWorkoutPercentage;
     private List<SetGroup> mSetGroups = new ArrayList<>();
+    private int mRepsToBeat;
+    private int mEstOneRm;
 
     /**
      * Constructor.
@@ -26,13 +29,19 @@ public class MainExercise extends Exercise implements Parcelable {
                         double increment,
                         ArrayList<ExerciseSet> exerciseSets,
                         List<SetGroup> setGroups,
-                        int workoutPercentage) {
+                        int workoutPercentage,
+                        int estOneRm,
+                        int repsToBeat) {
         mName = name;
         mWeight = weight;
         mIncrement = increment;
         mExerciseSets = exerciseSets;
         mWorkoutPercentage = workoutPercentage;
         mSetGroups = setGroups;
+        mEstOneRm = estOneRm;
+
+        mRepsToBeat = repsToBeat;
+
     }
 
     /**
@@ -90,6 +99,27 @@ public class MainExercise extends Exercise implements Parcelable {
     }
 
     /**
+     * Return the reps to beat for a new PR
+     */
+    public int getRepsToBeat() {
+        return mRepsToBeat;
+    }
+
+    /**
+     * Return the estimated One RM based on the last set
+     */
+    public int getEstOneRm() {
+        return mEstOneRm;
+    }
+
+    /**
+     * Recalculates the estimated One RM based on last set weight and reps
+     */
+    public void recalculateEstOneRm(){
+        mEstOneRm = WendlerMath.calculateOneRm(getLastSetWeight(), getLastSetProgress());
+    }
+
+    /**
      * Returns the set groups.
      */
     public List<SetGroup> getSetGroups() {
@@ -132,6 +162,8 @@ public class MainExercise extends Exercise implements Parcelable {
             dest.writeByte((byte) (0x01));
             dest.writeList(mSetGroups);
         }
+        dest.writeInt(mRepsToBeat);
+        dest.writeInt(mEstOneRm);
     }
 
     /**
@@ -154,6 +186,8 @@ public class MainExercise extends Exercise implements Parcelable {
         } else {
             mSetGroups = null;
         }
+        mRepsToBeat = in.readInt();
+        mEstOneRm = in.readInt();
     }
 
     /**
@@ -169,4 +203,5 @@ public class MainExercise extends Exercise implements Parcelable {
             return new MainExercise[size];
         }
     };
+
 }

--- a/wendler/src/main/java/se/johan/wendler/ui/adapter/MainExerciseAdapter.java
+++ b/wendler/src/main/java/se/johan/wendler/ui/adapter/MainExerciseAdapter.java
@@ -79,6 +79,7 @@ public class MainExerciseAdapter extends BaseAdapter {
 
         List<ExerciseSet> sets = getSetsByIndex(position);
         SetType setType = getTypeByIndex(position);
+        boolean shouldShowRepsToBeat = shouldShowRepsToBeat(setType, mMainExercise);
 
         final ViewHolder holder;
         if (convertView == null) {
@@ -88,6 +89,7 @@ public class MainExerciseAdapter extends BaseAdapter {
             holder.setOne = (TextView) convertView.findViewById(R.id.set_one);
             holder.setTwo = (TextView) convertView.findViewById(R.id.set_two);
             holder.setThree = (TextView) convertView.findViewById(R.id.set_three);
+            holder.repsToBeat = (TextView) convertView.findViewById(R.id.reps_to_beat);
             holder.imageView = (ImageView) convertView.findViewById(R.id.image_view);
             String text = getSetTypeString(setType, true);
             int color = ColorGenerator.DEFAULT.getColor(text);
@@ -103,6 +105,7 @@ public class MainExerciseAdapter extends BaseAdapter {
         final ExerciseSet setOne = sets.get(0);
         final ExerciseSet setTwo = sets.get(1);
         final ExerciseSet setThree = sets.get(2);
+        final int repsToBeat = getRepsToBeat();
 
         String plusSet = setThree.getType().equals(SetType.PLUS_SET) ? "+" : "";
 
@@ -120,6 +123,15 @@ public class MainExerciseAdapter extends BaseAdapter {
                 String.format(mContext.getString(R.string.exercise_set_three),
                         String.valueOf(setThree.getWeight()),
                         String.valueOf(setThree.getGoal())) + plusSet);
+
+        if (shouldShowRepsToBeat) {
+            holder.repsToBeat.setText(
+                    String.format(mContext.getString(R.string.reps_to_beat),
+                            String.valueOf(repsToBeat)));
+            holder.repsToBeat.setText(View.VISIBLE);
+        } else {
+            holder.repsToBeat.setVisibility(View.GONE);
+        }
 
         setOnClick(holder.setOne, setOne);
         setOnClick(holder.setTwo, setTwo);
@@ -142,6 +154,13 @@ public class MainExerciseAdapter extends BaseAdapter {
         setPaint(holder.setThree, setThree);
 
         return convertView;
+    }
+
+    /**
+     * Returns true if the 'reps to beat' label should be shown
+     */
+    private boolean shouldShowRepsToBeat(SetType setType, MainExercise mainExercise) {
+        return setType == SetType.REGULAR && mainExercise.getRepsToBeat() != -1;
     }
 
     /**
@@ -210,6 +229,13 @@ public class MainExerciseAdapter extends BaseAdapter {
     }
 
     /**
+     * Returns the reps to beat for a new PR
+     */
+    private int getRepsToBeat() {
+        return mMainExercise.getRepsToBeat();
+    }
+
+    /**
      * Returns the set type string based on set type and if it's displayed as a short.
      */
     private String getSetTypeString(SetType type, boolean shortType) {
@@ -237,5 +263,6 @@ public class MainExerciseAdapter extends BaseAdapter {
         public TextView setThree;
         public ImageView imageView;
         public TextDrawable textDrawable;
+        public TextView repsToBeat;
     }
 }

--- a/wendler/src/main/java/se/johan/wendler/util/WendlerMath.java
+++ b/wendler/src/main/java/se/johan/wendler/util/WendlerMath.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import se.johan.wendler.R;
 import se.johan.wendler.model.DeloadItem;
@@ -20,6 +21,9 @@ public class WendlerMath {
      * Calculate one rm for a given weight and repetitions.
      */
     public static int calculateOneRm(double weight, int reps) {
+        if(reps <= 0){
+            return -1;
+        }
         double mOneRm = weight * reps * 0.0333 + weight;
         return (int) Math.round(mOneRm);
     }
@@ -280,5 +284,39 @@ public class WendlerMath {
             intArray[i] = Integer.parseInt(stringArray[i]);
         }
         return intArray;
+    }
+
+    public static int getRepsToBeat(Context context, List<ExerciseSet> sets, int highestEstimated1RM) {
+        if(highestEstimated1RM == -1){
+            return -1;
+        }
+
+        ExerciseSet lastSet = sets.get(sets.size()-1);
+
+        double oneRmReps = calculateOneRmReps(lastSet.getWeight(), highestEstimated1RM);
+        int ceilOneRmReps = (int) Math.ceil(oneRmReps);
+
+        if(calculateOneRm(lastSet.getWeight(), ceilOneRmReps) <= highestEstimated1RM){
+            return ceilOneRmReps + 1;
+        }else{
+            return ceilOneRmReps;
+        }
+    }
+
+    public static double calculateOneRmReps(double weight, double oneRm){
+        double constant = 0.0333;
+        double mReps = 1 / ((weight * constant)/(oneRm-weight));
+        return mReps;
+
+        /**
+         * Proof (probably horrible math):
+         * O = (w*r*c) + w
+         * O–w = w*r*c
+         * (o-w)/r = w*c
+         * (o-w)*(1/r) = w*c
+         * 1/r = (w*c)/(o-w)
+         * R = 1/((w*c)/(o-w))
+         * QED
+         */
     }
 }

--- a/wendler/src/main/res/layout/card_main_exercise.xml
+++ b/wendler/src/main/res/layout/card_main_exercise.xml
@@ -66,6 +66,15 @@
                 android:paddingBottom="@dimen/spacing_small"
                 tools:text="22.5 x 5"
                 android:background="?attr/selectableItemBackground"/>
+
+            <TextView
+                android:id="@+id/reps_to_beat"
+                style="@style/CardView.Subtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="@dimen/spacing_small"
+                android:paddingBottom="@dimen/spacing_small"
+                tools:text="Reps for PR: 10"/>
         </LinearLayout>
     </LinearLayout>
 </android.support.v7.widget.CardView>

--- a/wendler/src/main/res/values/strings.xml
+++ b/wendler/src/main/res/values/strings.xml
@@ -93,6 +93,7 @@
     <string name="exercise_set_one">Set 1: %1$s &#x00d7; %2$s</string>
     <string name="exercise_set_two">Set 2: %1$s &#x00d7; %2$s</string>
     <string name="exercise_set_three">Set 3: %1$s &#x00d7; %2$s</string>
+    <string name="reps_to_beat">Reps to beat PR: %1$s</string>
     <string name="one_rm_with_number">Estimated 1RM: %1$s</string>
     <string name="performed_reps_with_number">Reps: %1$s</string>
     <string name="extra_exercise_weight">Weight: %1$s</string>


### PR DESCRIPTION
I was getting stuck trying to rebase so I just made one new commit in another branch. Below is the original request text and a screenshot:

I added a feature that allows users to quickly see how many reps they need to get on the last set of a workout, to set a new PR. I added a column to the workout table, where the estimated 1RM based on the last set is saved for each workout. This is then used when getting the new workout to calculate the required number of reps, which is displayed in the workout screen.

Please review, and don't hesitate to criticise. Let me know if any changes need to be made before this can be pulled. Thanks!

![reps to beat screenshot](https://cloud.githubusercontent.com/assets/3782086/6114173/a1d0c166-b09c-11e4-8c69-c8c8863b14f9.png)
